### PR TITLE
DATA-526: Updated default configuration for nginx

### DIFF
--- a/Dockerfile-nginx-base
+++ b/Dockerfile-nginx-base
@@ -3,3 +3,4 @@ FROM public.ecr.aws/nginx/nginx:latest
 
 # Healthchecks are important, for us and our ALBS.
 COPY nginx-source/release-version-nginx.txt /usr/share/nginx/html/release-version-nginx.txt
+COPY nginx-source/default.conf /etc/nginx/conf.d/default.conf

--- a/nginx-source/default.conf
+++ b/nginx-source/default.conf
@@ -1,0 +1,45 @@
+server {
+    listen       8080;
+    # listen  [::]:80;
+    server_name  localhost;
+
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+    }
+
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+
+    # proxy the PHP scripts to Apache listening on 127.0.0.1:80
+    #
+    #location ~ \.php$ {
+    #    proxy_pass   http://127.0.0.1;
+    #}
+
+    # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+    #
+    #location ~ \.php$ {
+    #    root           html;
+    #    fastcgi_pass   127.0.0.1:9000;
+    #    fastcgi_index  index.php;
+    #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
+    #    include        fastcgi_params;
+    #}
+
+    # deny access to .htaccess files, if Apache's document root
+    # concurs with nginx's one
+    #
+    #location ~ /\.ht {
+    #    deny  all;
+    #}
+}
+


### PR DESCRIPTION
This PR updates, the default configuration, to listen to port 8080, for our default nginx image. Its an unprivileged port, and matches many normal configurations used. It disables IPv6 at the same time.