### PR TITLE
DATA-1149: ECS container healthcheck for default-service

### DIFF
--- a/Dockerfile-nginx-base
+++ b/Dockerfile-nginx-base
@@ -4,4 +4,6 @@ FROM public.ecr.aws/nginx/nginx:latest
 # Healthchecks are important, for us and our ALBS.
 COPY nginx-source/release-version-nginx.txt /usr/share/nginx/html/release-version-nginx.txt
 COPY nginx-source/default.conf /etc/nginx/conf.d/default.conf
+COPY nginx-source/healthcheck.sh /healthcheck.sh
+
 RUN echo "OK" > /usr/share/nginx/html/healthcheck

--- a/nginx-source/healthcheck.sh
+++ b/nginx-source/healthcheck.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+DISK_USAGE=$(df -h | grep  '/$' | awk '{ print $5 }' | awk '{ print substr( $0, 1, length($0)-1 ) }')
+MAX_DISK_USAGE=95
+
+if [ $DISK_USAGE -gt $MAX_DISK_USAGE ]; then
+  echo "Disk usage too high ($DISK_USAGE%). Stopping container."
+  exit 1;
+fi
+
+I_NODES_USAGE=$(df -i | grep  '/$' | awk '{ print $5 }' | awk '{ print substr( $0, 1, length($0)-1 ) }')
+MAX_I_NODES_USAGE=98
+
+if [ $I_NODES_USAGE -gt $MAX_I_NODES_USAGE ]; then
+  echo "INODES count too high ($I_NODES_USAGE%). Stopping container."
+  exit 1;
+fi
+
+exit 0;


### PR DESCRIPTION
This PR, adds a basic container healthcheck to be used with the CMD-shell command.

the healthcheck-file was lifted from bm.app.berlingske.dk/environment/healthcheck.sh, where its a part of the docker-healthcheck command.